### PR TITLE
Replace proxy to target to use term proxy to http_proxy environment

### DIFF
--- a/lib/stubrec.js
+++ b/lib/stubrec.js
@@ -9,8 +9,9 @@ module.exports = Stubrec;
 function Stubrec(option) {
   var option = option || {};
   this.basepath = option.basepath || "";
-  this.proxy = option.proxy || "http://localhost:3001";
+  this.target = option.target || "http://localhost:3001";
   this.debug = option.debug || false;
+  this.proxy = typeof option.proxy !== "undefined" ? option.proxy : process.env.http_proxy;
 }
 
 Stubrec.prototype.fileFromRequest = function(requestUrl, filepath) {
@@ -46,7 +47,7 @@ Stubrec.prototype.record = function (filepath, req, res) {
     console.log("\033[36m" + "[request header] = " + JSON.stringify(req.headers) +"\033[39m");
     console.log("\033[36m" + "[request url] = " + req.url +"\033[39m");
     console.log("\033[36m" + "[store filepath] = " + this.basepath + filepath +"\033[39m");
-    console.log("\033[36m" + "[request proxy] = " + this.proxy +"\033[39m");
+    console.log("\033[36m" + "[request target] = " + this.target +"\033[39m");
   }
 
   var ss = new StringifyStream();
@@ -66,14 +67,17 @@ Stubrec.prototype.record = function (filepath, req, res) {
         json : req.body,
         method : req.method,
         headers : req.headers,
-        url: this.proxy + req.url
+        url: this.target + req.url,
+        proxy: this.proxy
       });
     } else {
-      reqstream = request(this.proxy + req.url);
+      reqstream = request({
+        url: this.target + req.url,
+        proxy: this.proxy
+      });
       req.pipe(reqstream);
     }
     reqstream.pipe(ss).pipe(fsWriteStream);
     reqstream.pipe(res);
   }.bind(this));
 };
-

--- a/test/test-bodyparser.js
+++ b/test/test-bodyparser.js
@@ -1,5 +1,5 @@
 var Stubrec = require('../index');
-var stubrec = new Stubrec({proxy : "http://localhost:3001", debug : true});
+var stubrec = new Stubrec({target : "http://localhost:3001", debug : true});
 var http = require("http");
 var fs = require("fs");
 var getRawBody = require('raw-body');
@@ -36,7 +36,7 @@ describe('Stubrec hijack request body', function() {
       path : '/jsonrpc',
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json' 
+        'Content-Type': 'application/json'
       }
     };
     var req = http.request(opt, function(res){
@@ -62,5 +62,3 @@ describe('Stubrec hijack request body', function() {
     req.end();
   });
 });
-
-

--- a/test/test-mkdirp.js
+++ b/test/test-mkdirp.js
@@ -1,5 +1,5 @@
 var Stubrec = require('../index');
-var stubrec = new Stubrec({proxy : "http://localhost:3001", debug : true});
+var stubrec = new Stubrec({target : "http://localhost:3001", debug : true});
 var http = require("http");
 var fs = require("fs");
 var assert = require("power-assert");
@@ -40,7 +40,7 @@ describe('Stubrec request', function() {
     });
     back.close();
   });
-  
+
   it("should return hello.json", function(done){
     http.get("http://localhost:3000/", function(res){
       var data = '';
@@ -57,4 +57,3 @@ describe('Stubrec request', function() {
     });
   });
 });
-

--- a/test/test-post.js
+++ b/test/test-post.js
@@ -1,5 +1,5 @@
 var Stubrec = require('../index');
-var stubrec = new Stubrec({proxy : "http://localhost:3001", debug : true});
+var stubrec = new Stubrec({target : "http://localhost:3001", debug : true});
 var http = require("http");
 var fs = require("fs");
 var assert = require("power-assert");
@@ -32,7 +32,7 @@ describe('Stubrec jsonrpc request', function() {
       path : '/jsonrpc',
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json' 
+        'Content-Type': 'application/json'
       }
     };
     var req = http.request(opt, function(res){
@@ -58,4 +58,3 @@ describe('Stubrec jsonrpc request', function() {
     req.end();
   });
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 var Stubrec = require('../index');
-var stubrec = new Stubrec({proxy : "http://localhost:3001", debug : true});
+var stubrec = new Stubrec({target : "http://localhost:3001", debug : true});
 var http = require("http");
 var fs = require("fs");
 var assert = require("power-assert");
@@ -25,7 +25,7 @@ describe('Stubrec request', function() {
     });
     back.close();
   });
-  
+
   it("should return hello.json", function(done){
     http.get("http://localhost:3000/", function(res){
       var data = '';


### PR DESCRIPTION
Modify to use it on http_proxy required environment.
So rename `proxy` to `target`. It seems  natural for "recording".
(maybe you used `proxy` because it is used in stubcell)
